### PR TITLE
Clean up exporter-go module paths

### DIFF
--- a/exporter-go/go.mod
+++ b/exporter-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/runyontr/opa_scorecard_exporter
+module github.com/runyontr/opa-scorecard/exporter-go
 
 go 1.16
 

--- a/exporter-go/main.go
+++ b/exporter-go/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/runyontr/opa_scorecard_exporter/pkg/opa"
+	"github.com/runyontr/opa-scorecard/exporter-go/pkg/opa"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"


### PR DESCRIPTION
Clean up the module path, which allows easy installation using `go install github.com/runyontr/opa-scorecard/exporter-go`

This also makes the Dockerfile extremely simple:

```docker
FROM golang:1.17-alpine as builder
RUN go install github.com/runyontr/opa-scorecard/exporter-go@v0.0.5
FROM alpine
COPY --from=builder /go/bin/exporter-go /bin/exporter-go
ENTRYPOINT ["/bin/exporter-go"]
```